### PR TITLE
Make lower-case font chars 5 pixels high

### DIFF
--- a/wwwbasic.js
+++ b/wwwbasic.js
@@ -3004,42 +3004,42 @@
     'XX   XX   XXX   XXXXXXX  XXXXX       XX  XXXXX                  ' +
     '                                                        XXXXXXX ' +
 
-    '  XX            XX                   XX           XXXX          ' +
-    '   XX           XX                   XX          XX  XX         ' +
-    '                XX                   XX  XXXX     XX            ' +
-    '         XXXXXX XXXXXX   XXXXX   XXXXXX XX  XX  XXXXXXX  XXXXX  ' +
+    '  XX            XX                   XX            XXXX         ' +
+    '   XX           XX                   XX           XX            ' +
+    '         XXXXXX XX       XXXXX       XX  XXXX     XX     XXXXX  ' +
+    '        XX   XX XXXXXX  XX       XXXXXX XX  XX  XXXXXXX XX   XX ' +
     '        XX   XX XX   XX XX      XX   XX XXXXXX    XX    XX   XX ' +
     '        XX   XX XX   XX XX      XX   XX XX        XX     XXXXXX ' +
     '         XXXXXX XXXXXX   XXXXX   XXXXXX  XXXXX    XX         XX ' +
     '                                                         XXXXX  ' +
-    'XX        XX       XX   XX       XX                             ' +
-    'XX        XX       XX   XX       XX                             ' +
-    'XX                      XX  XX   XX                             ' +
-    'XXXXXX   XXXX    XXXXX  XX XX    XX     XXXXXX  XXXXXX   XXXXX  ' +
-    'XX   XX   XX       XX   XXXX     XX     XX X XX XX   XX XX   XX ' +
-    'XX   XX   XX        XX  XX  XX   XX     XX X XX XX   XX XX   XX ' +
-    'XX   XX   XXXX      XX  XX   XX   XXXXX XX X XX XX   XX  XXXXX  ' +
+    'XX        XX       XX   XX        XXX                           ' +
+    'XX                      XX   XX    XX                           ' +
+    'XXXXXX   XXX      XXXX  XX  XX     XX   XXXXXX  XXXXXX   XXXXX  ' +
+    'XX   XX   XX        XX  XXXXX      XX   XX X XX XX   XX XX   XX ' +
+    'XX   XX   XX        XX  XX  XX     XX   XX X XX XX   XX XX   XX ' +
+    'XX   XX   XX        XX  XX   XX    XX   XX X XX XX   XX XX   XX ' +
+    'XX   XX  XXXX       XX  XX   XX   XXXX  XX X XX XX   XX  XXXXX  ' +
     '                  XXX                                           ' +
     '                                                                ' +
     '                                  XX                            ' +
-    '                         XXXXXX   XX                            ' +
-    'XXXXXX   XXXXX  XX XXX  XX      XXXXXXX XX   XX XX   XX XX   XX ' +
-    'XX   XX XX  XX  XXXX XX  XXXXX    XX    XX   XX XX   XX XX X XX ' +
+    'XXXXXX   XXXXX  XX XXX   XXXXXX   XX    XX   XX XX   XX XX   XX ' +
+    'XX   XX XX  XX  XXXX XX XX      XXXXXXX XX   XX XX   XX XX   XX ' +
+    'XX   XX XX  XX  XX       XXXXX    XX    XX   XX XX   XX XX X XX ' +
     'XXXXXX   XXXXX  XX           XX   XX XX XX   XX  XX XX  XX X XX ' +
-    'XX         XX   XX      XXXXXX     XXX   XXXXXX   XXX    XXXXX  ' +
-    'XX          XXX                                                 ' +
+    'XX          XX  XX      XXXXXX     XXX   XXXXXX   XXX    XXXXX  ' +
+    'XX          XX                                                  ' +
     '                             XX   XX    XX                 X    ' +
     '                           XX     XX      XX     XXX XX   XXX   ' +
-    '                           XX     XX      XX    XX XXX   XX XX  ' +
-    'XX   XX XX   XX XXXXXXX   XX      XX       XX           XX   XX ' +
-    ' XXXXX  XX   XX    XXX     XX     XX      XX            XX   XX ' +
-    ' XXXXX   XXXXXX  XXX       XX     XX      XX            XX   XX ' +
+    'XX   XX XX   XX XXXXXXX    XX     XX      XX    XX XXX   XX XX  ' +
+    ' XX XX  XX   XX    XXX    XX      XX       XX           XX   XX ' +
+    '  XXX   XX   XX   XXX      XX     XX      XX            XX   XX ' +
+    ' XX XX   XXXXXX  XXX       XX     XX      XX            XX   XX ' +
     'XX   XX      XX XXXXXXX      XX   XX    XX              XXXXXXX ' +
     '         XXXXX                                                  ' +
     ' XXXXXX                                                  XXXXXX ' +
     'XX      XX   XX                                         XX      ' +
-    'XX               XXXX                                   XX      ' +
-    'XX      XX   XX XX  XX   XXXXXX  XXXXXX  XXXXXX  XXXXXX XX      ' +
+    'XX               XXXX    XXXXXX  XXXXXX  XXXXX   XXXXXX XX      ' +
+    'XX      XX   XX XX  XX  XX   XX XX   XX XX   XX XX   XX XX      ' +
     'XX      XX   XX XXXXXX  XX   XX XX   XX XX   XX XX   XX XX      ' +
     'XX      XX   XX XX      XX   XX XX   XX XX   XX XX   XX XX      ' +
     ' XXXXXX  XXXXXX  XXXXX   XXXXXX  XXXXXX  XXXXXX  XXXXXX  XXXXXX ' +
@@ -3047,10 +3047,10 @@
     '                          XX      XX      XX      XXX     XXX   ' +
     '                          XX      XX      XX     XX XX   XX XX  ' +
     ' XXXX    XXXX    XXXX                           XX   XX XX   XX ' +
-    'XX  XX  XX  XX  XX  XX   XXXX    XXXX    XXXX   XXXXXXX XXXXXXX ' +
+    'XX  XX  XX  XX  XX  XX   XXX     XXX     XXX    XXXXXXX XXXXXXX ' +
     'XXXXXX  XXXXXX  XXXXXX    XX      XX      XX    XX   XX XX   XX ' +
     'XX      XX      XX        XX      XX      XX    XX   XX XX   XX ' +
-    ' XXXXX   XXXXX   XXXXX    XXXX    XXXX    XXXX  XX   XX XX   XX ' +
+    ' XXXXX   XXXXX   XXXXX   XXXX    XXXX    XXXX   XX   XX XX   XX ' +
     '                                                                ' +
     'XXXXXXX XXXXXXX XXXXXXX                                         ' +
     'XX      XX      XX                                              ' +
@@ -3062,7 +3062,7 @@
     '                                                                ' +
     '         XXXXX  XX   XX  XXXXXX  XXXXXX  XXXXXX  XXXXXX  XXXXXX ' +
     '        XX   XX XX   XX XX      XX      XX      XX      XX      ' +
-    '        XX   XX XX   XX XX      XX      XX      XX      XX      ' +
+    'XX   XX XX   XX XX   XX XX      XX      XX      XX      XX      ' +
     'XX   XX XX   XX XX   XX XX      XX      XX      XX      XX      ' +
     'XX   XX XX   XX XX   XX XX      XX      XX      XX      XX      ' +
     ' XXXXXX XX   XX XX   XX XX      XX      XX      XX      XX      ' +
@@ -3070,11 +3070,11 @@
     ' XXXXX                                                          ' +
     '          XX                                                    ' +
     '          XX                                                    ' +
-    '                                                                ' +
-    ' XXXXXX  XXXX    XXXXX  XX   XX XXXXXX  XXXXXX   XXXXXX  XXXXX  ' +
+    ' XXXXXX          XXXXX  XX   XX XXXXXX  XXXXXX   XXXXXX  XXXXX  ' +
+    'XX   XX  XXX    XX   XX XX   XX XX   XX XX   XX XX   XX XX   XX ' +
     'XX   XX   XX    XX   XX XX   XX XX   XX XX   XX XX   XX XX   XX ' +
     'XX   XX   XX    XX   XX XX   XX XX   XX XX   XX XX   XX XX   XX ' +
-    ' XXXXXX   XXXX   XXXXX   XXXXXX XX   XX XX   XX  XXXXXX  XXXXX  ' +
+    ' XXXXXX  XXXX    XXXXX   XXXXXX XX   XX XX   XX  XXXXXX  XXXXX  ' +
     '                                                                ' +
     '   XX                   X       X          XX                   ' +
     '                        X  X    X  X              XX XX XX XX   ' +


### PR DESCRIPTION
Current font looks odd with e and s being 5 high and all the others being 4.  A more traditional approach is 5 high for all of them except where you want to emphasize the stem on ascenders (or descenders).

Left as much as the rest of the font as-is except for the x (now allowed a clearer diagonal with 5 pixels high) and i (which had a double-arm at the top rather than the bottom)

Personally I think you could get away with a 1 pixel wide non-bold font given how this runs on the web and it would look more elegant. Let me know if you want to go that way :)