### PR TITLE
Make primes example more efficient

### DIFF
--- a/examples/primes.html
+++ b/examples/primes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<script src="https://google.github.io/wwwbasic/wwwbasic.js"></script>
+<script src=".../wwwbasic.js"></script>
 <script type="text/basic">
 PRINT 2; " ";
 FOR i = 3 TO 3000 STEP 2

--- a/examples/primes.html
+++ b/examples/primes.html
@@ -1,13 +1,25 @@
 <!DOCTYPE html>
-<script src="../wwwbasic.js"></script>
+<script src="https://google.github.io/wwwbasic/wwwbasic.js"></script>
 <script type="text/basic">
-
-FOR i = 2 TO 3000
-  prime = -1
-  FOR j = 2 TO i-1
-    IF i MOD j = 0 THEN prime = 0
-  NEXT j
-  IF prime THEN PRINT i; " ";
+PRINT 2; " ";
+FOR i = 3 TO 3000 STEP 2
+    IN = i
+    GOTO GetLengthOfNumber
+    Primetest:
+        prime = 1
+        FOR j = 3 TO (i / OUT)
+            IF i MOD j = 0 THEN prime = 0
+        NEXT j
+        IF prime THEN PRINT i; " ";
 NEXT i
-
+GOTO End
+GetLengthOfNumber:
+    A = 1
+    WHILE(IN > 9)
+        A = A + 1
+        IN = IN / 10
+    WEND
+    OUT = A + 1
+    A = 1
+    GOTO PrimeTest
 </script>

--- a/examples/primes.html
+++ b/examples/primes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<script src=".../wwwbasic.js"></script>
+<script src="../wwwbasic.js"></script>
 <script type="text/basic">
 PRINT 2; " ";
 FOR i = 3 TO 3000 STEP 2


### PR DESCRIPTION
Instead of looking at even numbers and extraneous factors, to check if x is prime you really only need to check if x is divisible by factors up to √x. This will make it run faster, and be better practice for intense prime-finding exercises! However, since this example only goes up to 3000, I use a VERY rough overestimate of the square root, as implementing a square root algorithm in BASIC would not only be wasteful for memory and computations at this size, but would also be a living nightmare for any programmer.

BTW:
Keep up the great work! Retro computing is awesome! 🎉